### PR TITLE
Store anonymous carts in ZODB rather than session

### DIFF
--- a/jazkarta/shop/browser/templates/checkout_form_authorize_net_sim.pt
+++ b/jazkarta/shop/browser/templates/checkout_form_authorize_net_sim.pt
@@ -36,9 +36,9 @@
         <tal:user_id tal:condition="python:view.user_id != None">
             <input type="hidden" name="user_id" tal:attributes="value string:${view/user_id}">
         </tal:user_id>
-        <tal:session_id tal:condition="python:view.user_id == None">
-            <input type="hidden" name="session_id" tal:attributes="value string:${view/session_id}">
-        </tal:session_id>
+        <tal:browser_id tal:condition="python:view.user_id == None">
+            <input type="hidden" name="browser_id" tal:attributes="value view/browser_id">
+        </tal:browser_id>
        <!-- <input type="hidden" name="x_cancel_url_text" value="Cancel">
         <input type="hidden" name="x_cancel_url" tal:attributes="value string:${view/x_cancel_url}"> -->
 

--- a/jazkarta/shop/browser/viewlets.py
+++ b/jazkarta/shop/browser/viewlets.py
@@ -2,7 +2,6 @@ from plone.app.layout.viewlets.common import ViewletBase
 from Products.Five import BrowserView
 from zope.cachedescriptors.property import Lazy as lazy_property
 from ..cart import Cart
-from ..interfaces import IProduct
 from ..interfaces import IPurchaseHandler
 from ..utils import format_currency
 

--- a/jazkarta/shop/cart.py
+++ b/jazkarta/shop/cart.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from cPickle import dumps, loads
 from datetime import datetime
 from decimal import Decimal
 from persistent.mapping import PersistentMapping
@@ -140,61 +139,56 @@ class LineItem(object):
 class Cart(object):
 
     @classmethod
-    def from_request(cls, request):
+    def from_request(cls, request, user_id=None, browser_id=None):
         """Get the user's shopping cart.
 
         The cart is an OrderedDict keyed by product UID.
 
-        It's stored in a session for anonymous users
-        and in a BTree on the site for logged-in users.
+        It's stored in a BTree on the site,
+        keyed by user id for logged-in users
+        and by the browser id cookie for anonymous users.
         If a user starts logged out and then logs in, the cart is moved.
         """
-        userid = get_current_userid()
-        if userid is not None:  # logged in
-            cart = storage.get_shop_data([userid, 'cart'])
-            if cart is None:
-                # not found; see if there's one in the session
-                # we can upgrade to persistent storage
-                if request.SESSION.has_key('cart'):
-                    # avoid cross-db reference
-                    cart = loads(dumps(request.SESSION['cart']))
-                    for item in cart['items']:
-                        item['user'] = userid
-                    del request.SESSION['cart']
+        if user_id is None:
+            user_id = get_current_userid()
+        if browser_id is None:
+            bm = get_site().session_data_manager.getBrowserIdManager()
+            browser_id = bm.getBrowserId()
+
+        if user_id is not None:  # logged in
+            storage_id = user_id
+            data = storage.get_shop_data([user_id, 'cart'])
+            if data is None:
+                # not found; see if there's an anonymous one
+                # we can upgrade to be stored by user id
+                data = storage.get_shop_data([browser_id, 'cart'])
+                if data is not None:
+                    for item in data['items']:
+                        item['user'] = user_id
+                    storage.del_shop_data([browser_id])
                 else:
                     # create a new cart
-                    cart = PersistentMapping()
-                storage.set_shop_data([userid, 'cart'], cart)
+                    data = PersistentMapping()
+                storage.set_shop_data([user_id, 'cart'], data)
         else:
-            # not logged in; keep cart in session
-            session = request.SESSION
-            if not session.has_key('cart'):
-                session.set('cart', PersistentMapping())
-            cart = session['cart']
+            storage_id = browser_id
+            data = storage.get_shop_data([browser_id, 'cart'])
+            if data is None:
+                data = PersistentMapping()
 
-        return Cart(cart, request)
+        return Cart(storage_id, data, request)
 
-    @classmethod
-    def from_session_id(cls, request, user_id, session_id):
-
-        if user_id is not None:  # logged in user
-            cart = storage.get_shop_data([user_id, 'cart'])
-        else:
-            # anonymous user
-            session_manager = get_site().session_data_manager
-            cart = session_manager.getSessionDataByKey(session_id)['cart']
-
-        return Cart(cart, request)
-
-    def __init__(self, data, request):
+    def __init__(self, storage_id, data, request):
         if 'items' not in data:
             data['items'] = OrderedDict()
         self._items = data['items']
+        self.storage_id = storage_id
         self.data = data
         self.request = request
 
     def clone(self):
         return Cart(
+            self.storage_id,
             copy.deepcopy(self.data),
             self.request,
         )
@@ -225,6 +219,7 @@ class Cart(object):
         This is necessary since OrderedDict isn't persistence-aware.
         """
         self.data['items'] = self._items
+        storage.set_shop_data([self.storage_id, 'cart'], self.data)
 
     def clear(self):
         items = self._items

--- a/jazkarta/shop/storage.py
+++ b/jazkarta/shop/storage.py
@@ -26,6 +26,16 @@ def set_shop_data(path, value):
     storage[path[-1]] = value
 
 
+def del_shop_data(path):
+    storage = get_storage(for_write=True)
+    for key in path[:-1]:
+        if key not in storage:
+            storage[key] = OOBTree()
+    key = path[-1]
+    if key in storage:
+        del storage[key]
+
+
 def increment_shop_data(path, delta):
     storage = get_storage(for_write=True)
     for key in path[:-1]:


### PR DESCRIPTION
This switches to storing anonymous users' carts in the ZODB rather than in a session. The cart is not stored until something is added to the cart, so this hopefully won't cause a ton of writes.