### PR TITLE
Pull in template change from jazkarta.shop

### DIFF
--- a/jazkarta/shop/browser/templates/checkout_cart.pt
+++ b/jazkarta/shop/browser/templates/checkout_cart.pt
@@ -1,5 +1,6 @@
 <div id="cartFormWrapper"
-     tal:define="cart view/old_cart|view/cart;
+     tal:define="cart view/old_cart|nothing;
+                 cart python:cart or view.cart;
                  can_edit view/cart_is_editable|python:False;
                  can_refund view/show_refund_column|nothing">
 <input type="hidden" name="total_order_amount" id="total_order_amount"


### PR DESCRIPTION
@fulv This change, and an identical change to the jbot override in nci.content, appears to fix the problem. The diff between `master` and `nci-2022` is **very large**, and I'm not a good person to make the call on a rebase here. I did take a quick look down that road, however, and it looked like it would be pretty clean, based on a [comparison](https://github.com/jazkarta/jazkarta.shop/compare/master...nci-2022).