### PR TITLE
More efficient mechanism for fetching/batching orders in the control panel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,13 @@
 Changelog
 
+- using Pickadate pattern to choose dates in @@jazkarta-shop-orders
+
 - Python 3 support, (Archetypes and UPS shipping support for python 2.x only)
 
 - Stripe elements support
 
-- Authorize.net SIM is deprecating the use of MD5. 
-  Added support for the the SHA512 that replaces it 
+- Authorize.net SIM is deprecating the use of MD5.
+  Added support for the the SHA512 that replaces it
   (requires the signature key is specified)
 
 - Refactored checkout forms into separate modules

--- a/jazkarta/shop/browser/controlpanel.py
+++ b/jazkarta/shop/browser/controlpanel.py
@@ -81,7 +81,7 @@ def _fetch_orders(part, key=(), csv=False):
                         href = '';
                 else:
                     href = title = i.get('href', '')
-                    
+
                 if csv:
                     # special parsing of items for csv export
                     item_str += u'{} x {} @ ${}'.format(
@@ -154,13 +154,11 @@ class DateMixin(object):
     def endDate(self):
         """ return end date - date picker
         """
-        end_date_day = self.request.get('End-Date_day')
-        end_date_month = self.request.get('End-Date_month')
-        end_date_year = self.request.get('End-Date_year')
-        if end_date_day is not None:
-            ed = datetime.date(int(end_date_year),
-                               int(end_date_month),
-                               int(end_date_day))
+        # pat-pickadate gives us a string ex: '2022-12-31'
+        end_date = self.request.get('End-Date')
+
+        if end_date:
+            ed = datetime.date(*map(int, end_date.split('-')))
         else:
             if self.orders_exist:
                 ed = self.to_datetime(self.most_recent_order_date,
@@ -172,13 +170,12 @@ class DateMixin(object):
     def startDate(self):
         """ return start date - date picker
         """
-        start_date_day = self.request.get('Start-Date_day')
-        start_date_month = self.request.get('Start-Date_month')
-        start_date_year = self.request.get('Start-Date_year')
-        if start_date_day is not None:
-            sd = datetime.date(int(start_date_year),
-                               int(start_date_month),
-                               int(start_date_day))
+
+        # pat-pickadate gives us a string ex: '2022-12-31'
+        start_date = self.request.get('Start-Date')
+
+        if start_date:
+            sd = datetime.date(*map(int, start_date.split('-')))
         else:
             if self.orders_exist:
                 sd = self.to_datetime(self.first_order_date,
@@ -207,7 +204,8 @@ class OrderControlPanelView(ControlPanelFormWrapper, DateMixin, SiteSetupLinkMix
         orders = list(_fetch_orders(storage.get_storage(), key=(), csv=False))
         orders.sort(key=lambda o: o.get('date_sort', ''), reverse=True)
         start = int(self.request.get('b_start', 0))
-
+        selected_start = self.startDate()
+        selected_end = self.endDate()
         if len(orders) > 0:
             self.orders_exist = True
 

--- a/jazkarta/shop/browser/controlpanel.py
+++ b/jazkarta/shop/browser/controlpanel.py
@@ -247,7 +247,7 @@ class ExportShopOrders(BrowserView, DateMixin):
         selected_end = self.endDate()
         # get shop order entries
         order_sequence = LazyFilteredOrders(
-            storage.get_storage(), selected_start, selected_end, csv=False
+            storage.get_storage(), selected_start, selected_end, csv=True
         )
         orders_csv = StringIO()
 

--- a/jazkarta/shop/browser/controlpanel.py
+++ b/jazkarta/shop/browser/controlpanel.py
@@ -180,7 +180,9 @@ class DateMixin(object):
     def check_date_integrity(self):
         """ returns False if start_date specified is later than the end_date
         """
-        if self.startDate() > self.endDate():
+        start = self.startDate()
+        end = self.endDate()
+        if start and end and start >= end:
             return False
         return True
 
@@ -289,7 +291,7 @@ class ExportShopOrders(BrowserView, DateMixin):
             orders_csv.close()
 
             # filename generation with date range included
-            start = selected_start or order_sequence.earliest_date 
+            start = selected_start or order_sequence.earliest_date
             end = selected_end or order_sequence.latest_date
             end_str = end.strftime(u'%m%d%Y')
             start_str = start.strftime(u'%m%d%Y')

--- a/jazkarta/shop/browser/controlpanel.py
+++ b/jazkarta/shop/browser/controlpanel.py
@@ -92,10 +92,10 @@ class LazyFilteredOrders(Lazy):
         data['date_sort'] = date.isoformat() if hasattr(date, 'isoformat') else ''
         data['userid'] = user or 'Anonymous'
         data['orderid'] = '{}|{}'.format(user or '_orders_', data['date_sort'])
-        data['taxes'] = sum(item.get('tax', 0) for item in data.get('taxes', ()))
+        data['taxes'] = sum(item.get('tax', Decimal('0.00')) for item in data.get('taxes', ()))
         items = list(data.get('items', {}).values())
-        data['total'] = (sum((i.get('price', 0.0) * i.get('quantity', 1)) for i in items) +
-                         data['taxes'] + data.get('ship_charge', 0))
+        data['total'] = (sum((i.get('price', Decimal('0.00')) * i.get('quantity', 1)) for i in items) +
+                         data['taxes'] + data.get('ship_charge', Decimal('0.00')))
 
         item_str = u'<ul>'
         if csv:
@@ -117,14 +117,14 @@ class LazyFilteredOrders(Lazy):
             if csv:
                 # special parsing of items for csv export
                 item_str += u'{} x {} @ ${}'.format(
-                        title, i.get('quantity', 1), i.get('price', 0.0)
+                        title, i.get('quantity', 1), i.get('price', Decimal('0.00'))
                 )
                 # add new line character to all but last item
                 if i != items[len(items)-1]:
                     item_str += u'\n'
             else:
                 item_str += u'<li><a href="{}">{}</a> x {} @ ${}</li>'.format(
-                    href, title, i.get('quantity', 1), i.get('price', 0.0)
+                    href, title, i.get('quantity', 1), i.get('price', Decimal('0.00'))
                 )
         data['items'] = item_str + u'</ul>'
         if csv:

--- a/jazkarta/shop/browser/templates/orders_controlpanel.pt
+++ b/jazkarta/shop/browser/templates/orders_controlpanel.pt
@@ -16,7 +16,7 @@
     <h1 class="documentFirstHeading">Shop Orders</h1>
 
     <form id="update-order-selection" name="update-order-selection" method="GET"
-              tal:attributes="action string:${view/__name__}">
+              tal:attributes="action view/__name__|string:jazkarta-shop-orders">
         <div>
              <table id="shop-order-date-selection-table">
                  <tbody>

--- a/jazkarta/shop/browser/templates/orders_controlpanel.pt
+++ b/jazkarta/shop/browser/templates/orders_controlpanel.pt
@@ -15,7 +15,7 @@
     </a>
     <h1 class="documentFirstHeading">Shop Orders</h1>
 
-    <form id="update-order-selection" name="update-order-selection" method="post"
+    <form id="update-order-selection" name="update-order-selection" method="GET"
               tal:attributes="action string:${view/__name__}">
         <div>
              <table id="shop-order-date-selection-table">
@@ -65,7 +65,13 @@
             </tal:bad_dates>
         <div>
             <form id="export_csv" name="export-csv2" method="post"
-                tal:attributes="action string:${context/absolute_url}/@@export-shop-orders-csv?first_order=${view/end_index}&last_order=${view/start_index}">
+                  tal:attributes="action string:${context/absolute_url}/@@export-shop-orders-csv">
+                <input name="Start-Date"
+                       type="hidden"
+                       tal:attributes="value python:request.get('Start-Date', None)" />
+                <input name="End-Date"
+                       type="hidden"
+                       tal:attributes="value python:request.get('End-Date', None)" />
                 <button id="export_csv_button" type="submit" name="export_csv">Export CSV</button>
             </form>
         </div>
@@ -83,18 +89,33 @@
         </tr>
       </thead>
       <tbody>
-          <tr tal:repeat="entry batch">
-            <tal:value repeat="key view/keys">
+          <tal:row repeat="entry batch">
+          <tr tal:define="oddrow repeat/entry/odd" tal:attributes="class python:oddrow and 'odd' or 'even'">
+            <tal:value repeat="key view/keys" >
                 <td tal:content="structure python:entry.get(key, '')">Value</td>
             </tal:value>
             <td>
               <a tal:attributes="href string:@@jazkarta-shop-order-details?order_id=${entry/orderid}">Show Details</a>
+            </td>
           </tr>
+          </tal:row>
       </tbody>
     </table>
     <tal:batchnavigation define="batchnavigation nocall:context/@@batchnavigation"
                          replace="structure python:batchnavigation(batch)" />
   </div>
+  <script>
+    $(window).on('load', function () {
+        $('input.pattern-pickadate-date').on('change', function () {
+            window.setTimeout(function () {
+                var $start = $('input[name="Start-Date"][type!="hidden"]');
+                var $end = $('input[name="End-Date"][type!="hidden"]');
+                $('input[type="hidden"][name="Start-Date"]').val($start.val());
+                $('input[type="hidden"][name="End-Date"]').val($end.val());
+            }, 50);
+        });
+    });
+  </script>
 </metal:main>
 </body>
 </html>

--- a/jazkarta/shop/browser/templates/orders_controlpanel.pt
+++ b/jazkarta/shop/browser/templates/orders_controlpanel.pt
@@ -27,33 +27,24 @@
                         <th></th>
                     </tr>
                     <tr>
-                         <td class="order-date-picker-box">
-                            <tal:define define="show_hm python:False;
-                                                show_ymd python:True;
-                                                starting_year python:2016;
-                                                ending_year python:None;
-                                                future_years python:0;
-                                                formname string:ShopOrders;
-                                                inputvalue python:view.startDate().strftime(u'%Y-%m-%d');
-                                                inputname string:Start-Date">
-                            <metal:box use-macro="here/jazkarta.shop.calendar_macros/macros/JazkartaShopCalendarDatePickerBox|default">
-                            </metal:box>
-                            </tal:define>
+                        <td class="order-date-picker-box"
+                            tal:define="fieldname string:Start-Date">
+                            <input class="pat-pickadate"
+                                   name="Start-Date"
+                                   data-pat-pickadate="time:false"
+                                   tal:attributes="id string:ShopOrders_${fieldname};
+                                                   name fieldname;
+                                                   value python:request.get(fieldname, None)" />
                         </td>
-                        <td class="order-date-picker-box">
-                            <tal:define define="show_hm python:False;
-                                                show_ymd python:True;
-                                                starting_year python:2016;
-                                                ending_year python:None;
-                                                future_years python:0;
-                                                formname string:ShopOrders;
-                                                inputvalue python:view.endDate().strftime(u'%Y-%m-%d');
-                                                inputname string:End-Date">
-                            <metal:box use-macro="here/jazkarta.shop.calendar_macros/macros/JazkartaShopCalendarDatePickerBox|default">
-                            </metal:box>
-                            </tal:define>
+                        <td class="order-date-picker-box"
+                            tal:define="fieldname string:End-Date">
+                            <input class="pat-pickadate"
+                                   name="End-Date"
+                                   data-pat-pickadate="time:false"
+                                   tal:attributes="id string:ShopOrders_${fieldname};
+                                                   name fieldname;
+                                                   value python:request.get(fieldname, None)" />
                         </td>
-
                     </tr>
                  </tbody>
              </table>

--- a/jazkarta/shop/browser/templates/shipping_methods_controlpanel.pt
+++ b/jazkarta/shop/browser/templates/shipping_methods_controlpanel.pt
@@ -12,14 +12,15 @@
     <a tal:attributes="href view/plone_control_panel" class="link-parent" id="setup-link">
         Site Setup
     </a>
-  <div data-pat-plone-modal='{"actionOptions": {"displayInModal": false}}'>
+  <div data-pat-plone-modal='{"actionOptions": {"displayInModal": false}}'
+       tal:define="view_name view/__name__|string:jazkarta-shop-shipping-methods">
     <h1 class="documentFirstHeading">Shipping Methods</h1>
 
     <tal:using_p5 tal:condition="view/using_plone5">
-        <a class="pat-plone-modal green button" href="${context/absolute_url}/${view/__name__}/+"><button>Add Shipping Method</button></a>
+        <a class="pat-plone-modal green button" href="${context/absolute_url}/${view_name}/+"><button>Add Shipping Method</button></a>
     </tal:using_p5>
     <tal:using_p4 tal:condition="not:view/using_plone5">
-        <a tal:attributes="href string:${context/absolute_url}/${view/__name__}/+"><button>Add Shipping Method</button></a>
+        <a tal:attributes="href string:${context/absolute_url}/${view_name}/+"><button>Add Shipping Method</button></a>
     </tal:using_p4>
 
     <table class="listing">
@@ -37,10 +38,10 @@
         <td tal:content="python:view.format_calculation(method['calculation'])" tal:on-error="nothing" />
         <td>
           <tal:using_p5 tal:condition="view/using_plone5">
-            <a class="pat-plone-modal" href="${context/absolute_url}/${view/__name__}/${method/key}">Edit</a>
+            <a class="pat-plone-modal" href="${context/absolute_url}/${view_name}/${method/key}">Edit</a>
           </tal:using_p5>
           <tal:using_p4 tal:condition="not:view/using_plone5">
-            <a tal:attributes="href string:${context/absolute_url}/${view/__name__}/${method/key}">Edit</a>
+            <a tal:attributes="href string:${context/absolute_url}/${view_name}/${method/key}">Edit</a>
           </tal:using_p4>
         </td>
       </tr>

--- a/jazkarta/shop/validators.py
+++ b/jazkarta/shop/validators.py
@@ -1,4 +1,4 @@
-from Products.validation.validators.BaseValidators import EMAIL_RE
+from Products.CMFPlone.PloneTool import EMAIL_RE
 from zope.interface import Invalid
 import re
 

--- a/jazkarta/shop/validators.py
+++ b/jazkarta/shop/validators.py
@@ -7,6 +7,8 @@ FULL_DOMAIN_RE = re.compile(r'^[^@]+@[^@.]+\.[^@]+$')
 
 
 def is_email(value):
-    if not EMAIL_RE.match(value) or not FULL_DOMAIN_RE.match(value):
+    # EMAIL_RE may or may not be compiled depending on Plone version,
+    # so to be more generally compatible, we use re.match() for this:
+    if not re.match(EMAIL_RE, value) or not FULL_DOMAIN_RE.match(value):
         raise Invalid(u'Please enter a valid e-mail address.')
     return True

--- a/jazkarta/shop/validators.py
+++ b/jazkarta/shop/validators.py
@@ -7,6 +7,6 @@ FULL_DOMAIN_RE = re.compile(r'^[^@]+@[^@.]+\.[^@]+$')
 
 
 def is_email(value):
-    if not re.match('^' + EMAIL_RE, value) or not FULL_DOMAIN_RE.match(value):
+    if not EMAIL_RE.match(value) or not FULL_DOMAIN_RE.match(value):
         raise Invalid(u'Please enter a valid e-mail address.')
     return True


### PR DESCRIPTION
The prior implementation retrieved all orders and then sorted them before filtering them by date. This implementation retrieves only the keys (which include a date), filters and sorts those keys, and then provides a lazy list implementation for retrieving the order items which can be used for batching.

This will also require some changes to [jazkarta.pfg.jazshop](https://github.com/jazkarta/jazkarta.pfg.jazshop) which imports and uses the private `_fetch_orders()` function.