### PR TITLE
Remove empty carts

### DIFF
--- a/jazkarta/shop/browser/checkout/__init__.py
+++ b/jazkarta/shop/browser/checkout/__init__.py
@@ -136,7 +136,6 @@ class CheckoutFormBase(BrowserView, P5Mixin):
         is still intact in case `store_order` needs to be retried.
         """
         self.cart.clear()
-        self.cart.save()
 
     def thankyou_page(self):
         if self.order_id is None:

--- a/jazkarta/shop/browser/checkout/__init__.py
+++ b/jazkarta/shop/browser/checkout/__init__.py
@@ -136,6 +136,7 @@ class CheckoutFormBase(BrowserView, P5Mixin):
         is still intact in case `store_order` needs to be retried.
         """
         self.cart.clear()
+        self.cart.save()
 
     def thankyou_page(self):
         if self.order_id is None:

--- a/jazkarta/shop/cart.py
+++ b/jazkarta/shop/cart.py
@@ -185,7 +185,6 @@ class Cart(object):
                 else:
                     # create a new cart
                     data = PersistentMapping()
-                storage.set_shop_data([user_id, 'cart'], data)
         else:
             storage_id = browser_id
             data = storage.get_shop_data([browser_id, 'cart'])
@@ -228,6 +227,7 @@ class Cart(object):
     def __delitem__(self, cart_id):
         del self._items[cart_id]
         notify(ItemRemoved(self))
+        self.save()
 
     @property
     def items(self):

--- a/jazkarta/shop/cart.py
+++ b/jazkarta/shop/cart.py
@@ -250,6 +250,7 @@ class Cart(object):
         items.clear()
         self.data.clear()
         self.data['items'] = items
+        self.save()
 
     @property
     def itemcount(self):

--- a/jazkarta/shop/cart.py
+++ b/jazkarta/shop/cart.py
@@ -240,7 +240,10 @@ class Cart(object):
         """
         self.data['items'] = self._items
         if self.storage_id:
-            storage.set_shop_data([self.storage_id, 'cart'], self.data)
+            if len(self.data['items']):
+                storage.set_shop_data([self.storage_id, 'cart'], self.data)
+            else:
+                storage.del_shop_data([self.storage_id, 'cart'])
 
     def clear(self):
         items = self._items

--- a/jazkarta/shop/storage.py
+++ b/jazkarta/shop/storage.py
@@ -29,11 +29,16 @@ def set_shop_data(path, value):
 def del_shop_data(path):
     storage = get_storage(for_write=True)
     for key in path[:-1]:
+        # We couldn't find a parent key, bail
         if key not in storage:
-            storage[key] = OOBTree()
+            return
+        storage = storage[key]
     key = path[-1]
     if key in storage:
         del storage[key]
+    # If the parent has no remaining keys, delete it too
+    if len(storage.keys()) == 0:
+        del_shop_data(path[:-1])
 
 
 def increment_shop_data(path, delta):

--- a/jazkarta/shop/storage.py
+++ b/jazkarta/shop/storage.py
@@ -37,7 +37,7 @@ def del_shop_data(path):
     if key in storage:
         del storage[key]
     # If the parent has no remaining keys, delete it too
-    if len(storage.keys()) == 0:
+    if len(storage.keys()) == 0 and len(path) > 1:
         del_shop_data(path[:-1])
 
 


### PR DESCRIPTION
This PR makes some small changes to the persistent cart functionality so that empty carts are persisted on every cart lookup, and cart objects are removed from the storage when the cart is cleared (either manually or automatically after checkout). If the `cart` is the only object stored under a parent key (i.e. a user id or browser session id key), then the parent key will be deleted as well.