### PR TITLE
Retrying subscription transactions with increasing delays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Build jazkarta.shop docker image
         run: docker build . -t jazkarta.shop
         env:
-           DOCKER_BUILDKIT: "1" 
+           DOCKER_BUILDKIT: "1"
 
       - name: Start Plone server
-        run: docker-compose up -d
+        run: docker compose up -d
         env:
-           DOCKER_BUILDKIT: "1" 
+           DOCKER_BUILDKIT: "1"
 
       - name: Check that jazkarta.shop was installed
         run: curl --fail -v http://localhost:8080/Plone/review-cart
@@ -39,4 +39,4 @@ jobs:
 
       - name: Print plone server logs
         if: always()  # This step should be also run when a previous step failed
-        run: docker-compose logs plone
+        run: docker compose logs plone

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - data:/data
     ports:
     - "8100"
-  # The `dummy` service is here to make sure `docker-compose up` exits only when
+  # The `dummy` service is here to make sure `docker compose up` exits only when
   # `plone`'s health is `healthy`.
   dummy:
     image: busybox

--- a/jazkarta/shop/browser/checkout/authorize_net_accept_js.py
+++ b/jazkarta/shop/browser/checkout/authorize_net_accept_js.py
@@ -18,6 +18,7 @@ from ...utils import get_setting
 from ...utils import resolve_uid
 from ...utils import run_in_transaction
 from ...validators import is_email
+from ... import logger
 
 SUBSCRIPTION_SLEEP_INCREMENT = 2
 SUBSCRIPTION_RETRIES = 4
@@ -69,7 +70,12 @@ class CheckoutFormAuthorizeNetAcceptJs(CheckoutFormBase):
                     raise e
                 # Retry after delay for specific error
                 if 'Invalid OTS Token' in str(e):
-                    time.sleep(SUBSCRIPTION_SLEEP_INCREMENT * self.retries)
+                    delay = SUBSCRIPTION_SLEEP_INCREMENT * self.retries
+                    logger.warn(
+                        "Error on Auth.net subscription request. Retrying "
+                        "({}) after {} seconds".format(self.retries, delay)
+                    )
+                    time.sleep(delay)
                     continue
                 # Raise the error for any other error
                 raise e

--- a/jazkarta/shop/browser/checkout/authorize_net_accept_js.py
+++ b/jazkarta/shop/browser/checkout/authorize_net_accept_js.py
@@ -25,7 +25,9 @@ SUBSCRIPTION_RETRIES = 4
 
 
 class CheckoutFormAuthorizeNetAcceptJs(CheckoutFormBase):
-    """ Renders a checkout form set up to submit through Stripe """
+    """ Renders a checkout form set up to submit through authorize.net Accept.js
+    """
+
     index = ViewPageTemplateFile(
         '../templates/checkout_form_authorize_net_accept_js.pt')
 

--- a/jazkarta/shop/browser/checkout/authorize_net_accept_js.py
+++ b/jazkarta/shop/browser/checkout/authorize_net_accept_js.py
@@ -1,4 +1,5 @@
 import six
+import time
 from AccessControl import getSecurityManager
 from persistent.mapping import PersistentMapping
 from ZODB.POSException import ConflictError
@@ -17,7 +18,9 @@ from ...utils import get_setting
 from ...utils import resolve_uid
 from ...utils import run_in_transaction
 from ...validators import is_email
-import time
+
+SUBSCRIPTION_SLEEP_INCREMENT = 2
+SUBSCRIPTION_RETRIES = 4
 
 
 class CheckoutFormAuthorizeNetAcceptJs(CheckoutFormBase):
@@ -50,6 +53,26 @@ class CheckoutFormAuthorizeNetAcceptJs(CheckoutFormBase):
     capture_payment = True
     is_recurring = False
     recurring_months = None
+    retries = 0
+
+    def retry_subscription_request(self, opaque_data, contact_info):
+        while self.retries < SUBSCRIPTION_RETRIES:
+            try:
+                return ARBCreateSubscriptionRequest(
+                    self.cart, self.refId, opaque_data, contact_info,
+                    months=self.recurring_months
+                )
+            except PaymentProcessingException as e:
+                self.retries += 1
+                # Raise the error once retries have been exceeded
+                if self.retries >= SUBSCRIPTION_RETRIES:
+                    raise e
+                # Retry after delay for specific error
+                if 'Invalid OTS Token' in str(e):
+                    time.sleep(SUBSCRIPTION_SLEEP_INCREMENT * self.retries)
+                    continue
+                # Raise the error for any other error
+                raise e
 
     def handle_submit(self):
         if not len(self.cart.items):
@@ -104,9 +127,9 @@ class CheckoutFormAuthorizeNetAcceptJs(CheckoutFormBase):
 
             try:
                 if self.is_recurring:
-                    response = ARBCreateSubscriptionRequest(
-                        self.cart, self.refId, opaque_data, contact_info,
-                        months=self.recurring_months)
+                    response = self.retry_subscription_request(
+                        opaque_data, contact_info
+                    )
                 else:
                     transactionType = (
                         'authCaptureTransaction' if self.capture_payment
@@ -116,7 +139,7 @@ class CheckoutFormAuthorizeNetAcceptJs(CheckoutFormBase):
                         self.cart, self.refId, opaque_data, contact_info,
                         transactionType=transactionType)
             except PaymentProcessingException as e:
-                self.error = e.message
+                self.error = str(e)
 
         if not self.error:
             try:

--- a/jazkarta/shop/browser/checkout/stripe.py
+++ b/jazkarta/shop/browser/checkout/stripe.py
@@ -78,10 +78,10 @@ class CheckoutFormStripe(CheckoutFormBase):
             except PaymentProcessingException as e:
                 charge_result = {
                     'success': False,
-                    'err_msg': e.message,
+                    'err_msg': str(e),
                     'err_code': getattr(e, 'code', None),
                 }
-                self.error = e.message
+                self.error = str(e)
 
         if not self.error:
             try:


### PR DESCRIPTION
See jazkarta/nci.content#336 and specifically [this comment](https://github.com/jazkarta/nci.content/issues/336#issuecomment-2499302647)

Apparently Authorize.net AcceptJS will sometimes just fail to recognize a valid subscription payment nonce token when it's busy and it may be necessary to retry the transaction with a delay of up to 10 seconds. Right now NCI has a 5 second delay on the client side to aid with this, which impacts all transactions. However, since this issue seems specific to subscription transactions and a silent delay on the client seems disconcerting (especially if longer than 5 seconds), I think the delay probably belongs in jaz.shop. Additionally, it's only really possible to implement further incremental delays and retries on the server side.

This should repeat the transaction when it fails with a specific error code up to 4 times with a delay that increments by 2 seconds on each repeat. So if needed, the final transaction should occur 12 seconds after the initial try.

